### PR TITLE
Ticket #71 - Safely get users displayname

### DIFF
--- a/Modules/UserManagement.cs
+++ b/Modules/UserManagement.cs
@@ -50,7 +50,7 @@ namespace ELO.Modules
                         var user = db.Players.Find(Context.Guild.Id, p.UserId);
                         var field = new EmbedFieldBuilder
                         {
-                            Name = user?.DisplayName ?? p.UserId.ToString(),
+                            Name = user?.GetDisplayNameSafe() ?? p.UserId.ToString(),
                             Value = $"**User:** {MentionUtils.MentionUser(p.UserId)}\n" +
                             $"**Banned at:**  {p.ExpiryTime.ToString("dd MMM yyyy")}\n" +
                             $"**Ban Length:** {p.Length.GetReadableLength()}\n" +


### PR DESCRIPTION
[SUGGESTION] Add GetDisplayNameSafe to bans (banlist); the embed field title (actually field Name in this case) is affected by formatting